### PR TITLE
Ensure that equal types are passed to atomic op templates

### DIFF
--- a/src/percetto.cc
+++ b/src/percetto.cc
@@ -208,7 +208,7 @@ class PercettoDataSource : public perfetto::DataSource<PercettoDataSource> {
                 std::begin(tags));
       if (IsCategoryEnabled(s_percetto.categories[i]->ext->name, tags, config)) {
         std::atomic_fetch_or(&s_percetto.categories[i]->sessions,
-                             1 << args.internal_instance_index);
+                             1ul << args.internal_instance_index);
       }
     }
     UpdateGroupCategories();
@@ -220,7 +220,7 @@ class PercettoDataSource : public perfetto::DataSource<PercettoDataSource> {
   void OnStop(const DataSourceBase::StopArgs& args) override {
     for (int i = 0; i < s_percetto.category_count; i++) {
       std::atomic_fetch_and(&s_percetto.categories[i]->sessions,
-          ~(1 << args.internal_instance_index));
+          ~(1ul << args.internal_instance_index));
     }
     UpdateGroupCategories();
   }


### PR DESCRIPTION
Fixes compile errors with g++8:

   /usr/include/c++/8/atomic:1299:5: note: candidate:
   'template<class _ITp> _ITp std::atomic_fetch_and(volatile std::__atomic_base<_ITp>*, _ITp)'
     atomic_fetch_and(volatile __atomic_base<_ITp>* __a, _ITp __i) noexcept
     ^~~~~~~~~~~~~~~~
   /usr/include/c++/8/atomic:1299:5: note:   template argument deduction/substitution failed:
  ../src/percetto.cc:211:63: note:
    deduced conflicting types for parameter '_ITp'
      ('long unsigned int' and 'int')
        1 << args.internal_instance_index);

Signed-off-by: Gert Wollny <gert.wollny@collabora.com>