### PR TITLE
set shmem_size_hint to same as with vperfetto_min and make perfetto symbols hidden 

### DIFF
--- a/perfetto-sdk/meson.build
+++ b/perfetto-sdk/meson.build
@@ -50,7 +50,7 @@ perfetto_sdk_lib = static_library(
   'perfetto-sdk',
   perfetto_sdk_gen,
   dependencies: threads_dep,
-  cpp_args : ['-fdata-sections', '-ffunction-sections', '-Os'],
+  cpp_args : ['-fdata-sections', '-ffunction-sections', '-Os', '-fvisibility=hidden'],
 )
 
 perfetto_sdk_dep = declare_dependency(

--- a/src/percetto.cc
+++ b/src/percetto.cc
@@ -561,6 +561,7 @@ int percetto_init(size_t category_count,
 
   perfetto::TracingInitArgs args;
   args.backends = perfetto::kSystemBackend;
+  args.shmem_size_hint_kb = 32 * 1024;
   perfetto::Tracing::Initialize(args);
 
   return PercettoDataSource::Register() ? 0 : -1;


### PR DESCRIPTION
The first patch makes the warning go away that perfetto is initialized twice with different parameters, 
the second fixes a crash that would occure because the vperfetto_min call would try to use  the percetto/perfetto-sdk symbols. 