### PR TITLE
refactor to shared library

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -34,7 +34,7 @@ executable(
   'threads.cc',
   dependencies: percetto_dep,
   cpp_args : ['-fdata-sections', '-ffunction-sections', '-Os'],
-  link_args : ['-Wl,--gc-sections'],
+  link_args : ['-Wl,--gc-sections', '-pthread'],
 )
 
 executable(

--- a/examples/multi-perfetto-instance.c
+++ b/examples/multi-perfetto-instance.c
@@ -27,7 +27,8 @@
 #include "multi-perfetto-shlib.h"
 
 #define MY_PERCETTO_CATEGORIES(C, G) \
-  C(test, "Test events")
+  C(test, "Test events") \
+  C(test2, "Slow test2 events", "slow")
 
 PERCETTO_CATEGORY_DEFINE(MY_PERCETTO_CATEGORIES);
 

--- a/examples/multi-perfetto-shlib.c
+++ b/examples/multi-perfetto-shlib.c
@@ -18,7 +18,8 @@
 #include "multi-perfetto-shlib.h"
 
 #define MY_PERCETTO_CATEGORIES(C, G) \
-  C(shlib, "Shared lib test events")
+  C(shlib, "Shared lib test events") \
+  C(test2, "Non-slow test2 events")
 
 PERCETTO_CATEGORY_DEFINE(MY_PERCETTO_CATEGORIES);
 

--- a/examples/threads.cc
+++ b/examples/threads.cc
@@ -32,6 +32,8 @@
 PERCETTO_CATEGORY_DEFINE(MY_PERCETTO_CATEGORIES);
 
 PERCETTO_TRACK_DEFINE(mycount, PERCETTO_TRACK_COUNTER);
+PERCETTO_TRACK_DEFINE(trk2, PERCETTO_TRACK_COUNTER);
+PERCETTO_TRACK_DEFINE(trk3, PERCETTO_TRACK_COUNTER);
 
 static void test(const char* name) {
   pthread_setname_np(pthread_self(), name);
@@ -44,6 +46,8 @@ static void test(const char* name) {
     static int count = 1;
     count++;
     TRACE_COUNTER(test, mycount, count);
+    TRACE_COUNTER(test, trk2, count / 10);
+    TRACE_COUNTER(test, trk3, count / 100);
   }
 }
 
@@ -59,7 +63,19 @@ int main(void) {
 
   ret = PERCETTO_REGISTER_TRACK(mycount);
   if (ret != 0) {
-    fprintf(stderr, "warning: failed to register track: %d\n", ret);
+    fprintf(stderr, "warning: failed to register track1: %d\n", ret);
+    return -1;
+  }
+
+  ret = PERCETTO_REGISTER_TRACK(trk2);
+  if (ret != 0) {
+    fprintf(stderr, "warning: failed to register track2: %d\n", ret);
+    return -1;
+  }
+
+  ret = PERCETTO_REGISTER_TRACK(trk3);
+  if (ret != 0) {
+    fprintf(stderr, "warning: failed to register track3: %d\n", ret);
     return -1;
   }
 

--- a/examples/timestamps.c
+++ b/examples/timestamps.c
@@ -33,6 +33,7 @@ PERCETTO_CATEGORY_DEFINE(MY_PERCETTO_CATEGORIES);
 
 PERCETTO_TRACK_DEFINE(gpu, PERCETTO_TRACK_EVENTS);
 PERCETTO_TRACK_DEFINE(gpu_freq, PERCETTO_TRACK_COUNTER);
+PERCETTO_TRACK_DEFINE(present, PERCETTO_TRACK_EVENTS);
 
 static int trace_init(void) {
   int ret;
@@ -42,6 +43,7 @@ static int trace_init(void) {
   if (ret != 0)
     return ret;
   ret = PERCETTO_REGISTER_TRACK(gpu_freq);
+  ret = PERCETTO_REGISTER_TRACK(present);
   return PERCETTO_REGISTER_TRACK(gpu);
 }
 
@@ -87,8 +89,10 @@ int main(void) {
     TRACE_EVENT(gfx, "do_test_iteration");
     test();
 
+    TRACE_EVENT_BEGIN_ON_TRACK(gfx, present, 0, "present");
     struct timespec t = {0, 10000000};
     nanosleep(&t, NULL);
+    TRACE_EVENT_END_ON_TRACK(gfx, present, 0);
   }
 
   return 0;

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,14 +13,14 @@
 # limitations under the License.
 #
 
-percetto_lib = static_library(
+percetto_lib = shared_library(
   'percetto',
   'percetto.cc',
   'perfetto-port.cc',
   dependencies: perfetto_sdk_dep,
-  cpp_args : ['-fdata-sections', '-ffunction-sections', '-Os'],
+  cpp_args : ['-fvisibility=hidden', '-fdata-sections', '-ffunction-sections', '-Os'],
+  link_args : ['-Wl,--gc-sections', '-Wl,--exclude-libs,ALL'],
   install : true,
-  pic : true,
 )
 
 percetto_dep = declare_dependency(

--- a/src/percetto.h
+++ b/src/percetto.h
@@ -38,7 +38,8 @@ using std::size_t;
 extern "C" {
 #endif
 
-#define PERCETTO_MAX_CATEGORIES 256
+// Process-wide limits.
+#define PERCETTO_MAX_CATEGORIES 64
 #define PERCETTO_MAX_GROUP_CATEGORIES 32
 #define PERCETTO_MAX_GROUP_SIZE 4
 #define PERCETTO_MAX_CATEGORY_TAGS 4
@@ -220,6 +221,7 @@ extern "C" {
     .shmem_size_hint_kb = 0, \
     .shmem_page_size_hint_kb = 0, \
     .shmem_batch_commits_duration_ms = 0, \
+    .flags = 0, \
     ._reserved = NULL, \
   }
 
@@ -280,6 +282,7 @@ struct percetto_init_args {
   uint32_t shmem_size_hint_kb;
   uint32_t shmem_page_size_hint_kb;
   uint32_t shmem_batch_commits_duration_ms;
+  uint32_t flags;
   void* _reserved;
 };
 
@@ -344,6 +347,7 @@ struct percetto_event_debug_data {
 /**
  * See PERCETTO_INIT.
  */
+__attribute__((visibility("default")))
 int percetto_init(size_t category_count,
                   struct percetto_category** categories,
                   enum percetto_clock clock_id);
@@ -351,6 +355,7 @@ int percetto_init(size_t category_count,
 /**
  * See PERCETTO_INIT_ARGS.
  */
+__attribute__((visibility("default")))
 int percetto_init_with_args(size_t category_count,
                             struct percetto_category** categories,
                             enum percetto_clock clock_id,
@@ -359,6 +364,7 @@ int percetto_init_with_args(size_t category_count,
 /**
  * See PERCETTO_REGISTER_TRACK.
  */
+__attribute__((visibility("default")))
 int percetto_register_track(struct percetto_track* track);
 
 /**
@@ -369,24 +375,29 @@ int percetto_register_track(struct percetto_track* track);
  *
  * @param category Category data in persistent memory.
  */
+__attribute__((visibility("default")))
 int percetto_register_group_category(struct percetto_category* category);
 
 /** See TRACE_EVENT macros. */
+__attribute__((visibility("default")))
 void percetto_event_begin(struct percetto_category* category,
                           uint32_t sessions,
                           const char* name);
 
 /** See TRACE_EVENT macros. */
+__attribute__((visibility("default")))
 void percetto_event_end(struct percetto_category* category,
                         uint32_t sessions);
 
 /** See TRACE_INSTANT, TRACE_COUNTER, TRACE_ANY_WITH_ARGS macros. */
+__attribute__((visibility("default")))
 void percetto_event(struct percetto_category* category,
                     uint32_t sessions,
                     int32_t type,
                     const struct percetto_event_data* data);
 
 /** See TRACE_DEBUG macros. */
+__attribute__((visibility("default")))
 void percetto_event_extended(struct percetto_category* category,
                              uint32_t sessions,
                              int32_t type,


### PR DESCRIPTION
This depends on perfetto v22.0+.

With this change, it is no longer an error to call
init multiple times -- each time the provided
categories are added and registered with the
perfetto traced service.