### PR TITLE
CMake-based build and build-to-AAR support

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022, Collabora, Ltd.
+# SPDX-License-Identifier: CC0-1.0
+
+with section("format"):
+    line_width = 100
+    tab_size = 4
+
+    max_prefix_chars = 4
+
+    max_pargs_hwrap = 4
+    max_rows_cmdline = 1
+
+    keyword_case = 'upper'
+
+
+# Do not reflow comments
+
+with section("markup"):
+    enable_markup = False

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2022, Collabora, Ltd.
+
+build*/
+install*/
+.vscode/
+CMakeUserPresets.json
+maven_repo/*
+/*.pom
+/*.aar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,95 @@
+# Copyright 2021-2022, Collabora, Ltd.
+#
+# SPDX-License-Identifier: BSL-1.0
+
+cmake_minimum_required(VERSION 3.10)
+project(
+    percetto
+    VERSION 0.1.6.0
+    DESCRIPTION "A C wrapper for the C++ Perfetto tracing library.")
+
+# Increment every time the ABI changes
+set(PERCETTO_SONAME_VERSION 1)
+
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+    # we are the top level project
+    option(BUILD_EXAMPLES "Should we build the examples?" ON)
+else()
+    set(BUILD_EXAMPLES OFF)
+endif()
+
+if(NOT PERFETTO_SDK_PATH)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../perfetto/sdk)
+        set(PERFETTO_SDK_PATH
+            ${CMAKE_CURRENT_SOURCE_DIR}/../perfetto/sdk
+            CACHE PATH "The SDK directory of a recent Perfetto release.")
+    else()
+        message(FATAL_ERROR "Must set PERFETTO_SDK_PATH")
+    endif()
+endif()
+
+# Basic config stuff
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_STANDARD 17)
+include(GNUInstallDirs)
+find_package(Threads REQUIRED)
+
+if(ANDROID)
+    find_library(ANDROID_LOG log)
+
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+    option(INSTALL_FOR_PREFAB "Should we install for a manually-assembled prefab layout?" OFF)
+    if(INSTALL_FOR_PREFAB)
+        include(PrefabHelper)
+        setup_prefab()
+
+        setup_prefab_module(percetto)
+    endif()
+endif()
+
+# Perfetto SDK
+add_library(perfetto OBJECT ${PERFETTO_SDK_PATH}/perfetto.cc ${PERFETTO_SDK_PATH}/perfetto.h)
+target_link_libraries(perfetto PUBLIC Threads::Threads)
+target_include_directories(perfetto PUBLIC $<BUILD_INTERFACE:${PERFETTO_SDK_PATH}>)
+target_compile_options(perfetto PRIVATE -ffunction-sections -fdata-sections)
+
+# PerCetto
+add_subdirectory(src)
+
+# Optional examples
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+# Version usable in both build and install dirs.
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/percetto/percettoConfigVersion.cmake"
+    VERSION ${percetto_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+# This really minimal config file usable in both build and install dirs
+configure_file(cmake/percettoConfig.cmake
+               "${CMAKE_CURRENT_BINARY_DIR}/percetto/percettoConfig.cmake" COPYONLY)
+
+# Exported targets usable only for build
+export(
+    EXPORT percetto
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/percetto/percettoTargets.cmake"
+    NAMESPACE percetto::)
+
+# Only install if we are the top level project
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+    # Installed targets usable only for installed
+    set(PACKAGE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/percetto)
+    install(
+        EXPORT percetto
+        FILE percettoTargets.cmake
+        NAMESPACE percetto
+        DESTINATION ${PACKAGE_INSTALL_DIR})
+
+    # Install the files we share with the build tree.
+    install(
+        FILES cmake/percettoConfig.cmake
+              "${CMAKE_CURRENT_BINARY_DIR}/percetto/percettoConfigVersion.cmake"
+        DESTINATION ${PACKAGE_INSTALL_DIR})
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,9 +13,9 @@
             "hidden": true,
             "cacheVariables": {
                 "ANDROID_PLATFORM": "26",
-                "ANDROID_STL": "c++_shared",
+                "ANDROID_STL": "c++_static",
                 "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+                "CMAKE_BUILD_TYPE": "Release"
             },
             "toolchainFile": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake",
             "binaryDir": "${sourceDir}/build/${presetName}",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,135 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "Android_base",
+            "displayName": "Base build for Android",
+            "generator": "Ninja",
+            "hidden": true,
+            "cacheVariables": {
+                "ANDROID_PLATFORM": "26",
+                "ANDROID_STL": "c++_shared",
+                "CMAKE_ANDROID_NDK": "$env{ANDROID_NDK_HOME}",
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            },
+            "toolchainFile": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "installDir": "${sourceDir}/install/${presetName}"
+        },
+        {
+            "name": "Android_x86",
+            "inherits": "Android_base",
+            "cacheVariables": {
+                "ANDROID_ABI": "x86"
+            }
+        },
+        {
+            "name": "Android_x86_64",
+            "inherits": "Android_base",
+            "cacheVariables": {
+                "ANDROID_ABI": "x86_64"
+            }
+        },
+        {
+            "name": "Android_armeabi-v7a",
+            "inherits": "Android_base",
+            "cacheVariables": {
+                "ANDROID_ABI": "armeabi-v7a"
+            }
+        },
+        {
+            "name": "Android_arm64-v8a",
+            "inherits": "Android_base",
+            "cacheVariables": {
+                "ANDROID_ABI": "arm64-v8a"
+            }
+        },
+        {
+            "name": "Android_aar_base",
+            "inherits": "Android_base",
+            "cacheVariables": {
+                "INSTALL_FOR_PREFAB": "ON"
+            },
+            "installDir": "install/percetto",
+            "hidden": true
+        },
+        {
+            "name": "Android_x86_64_aar",
+            "inherits": "Android_aar_base",
+            "cacheVariables": {
+                "ANDROID_ABI": "x86_64"
+            }
+        },
+        {
+            "name": "Android_armeabi-v7a_aar",
+            "inherits": "Android_aar_base",
+            "cacheVariables": {
+                "ANDROID_ABI": "armeabi-v7a"
+            }
+        },
+        {
+            "name": "Android_arm64-v8a_aar",
+            "inherits": "Android_aar_base",
+            "cacheVariables": {
+                "ANDROID_ABI": "arm64-v8a"
+            }
+        },
+        {
+            "name": "Android_x86_aar",
+            "inherits": "Android_aar_base",
+            "cacheVariables": {
+                "ANDROID_ABI": "x86"
+            }
+        },
+        {
+            "name": "Linux_Ninja",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "installDir": "${sourceDir}/install"
+        },
+        {
+            "name": "Linux_Ninja_Clang",
+            "inherits": "Linux_Ninja",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "/usr/bin/clang",
+                "CMAKE_CXX_COMPILER": "/usr/bin/clang++"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "Android_aar_base",
+            "hidden": true,
+            "targets": [
+                "all",
+                "install"
+            ],
+            "verbose": true
+        },
+        {
+            "name": "Android_x86_aar",
+            "inherits": "Android_aar_base",
+            "configurePreset": "Android_x86_aar"
+        },
+        {
+            "name": "Android_x86_64_aar",
+            "inherits": "Android_aar_base",
+            "configurePreset": "Android_x86_64_aar"
+        },
+        {
+            "name": "Android_armeabi-v7a_aar",
+            "inherits": "Android_aar_base",
+            "configurePreset": "Android_armeabi-v7a_aar"
+        },
+        {
+            "name": "Android_arm64-v8a_aar",
+            "inherits": "Android_aar_base",
+            "configurePreset": "Android_arm64-v8a_aar"
+        }
+    ]
+}

--- a/CMakePresets.json.license
+++ b/CMakePresets.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2022, Collabora, Ltd.
+SPDX-License-Identifier: CC0-1.0

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ meson build -Dperfetto-sdk=path/to/perfetto/sdk
 meson compile -C build
 ```
 
+Alternately, you can use CMake. It will assume that you've cloned a recent
+release of Perfetto next to the percetto directory, unless you pass
+`-DPERFETTO_SDK_PATH=some/other/location`.
+
+```sh
+cmake -S . -B build -G Ninja
+ninja -C build
+```
+
 ## Directory Structure
 
 `perfetto-sdk` contains rules to locate and build Perfetto SDK.

--- a/build-aar.sh
+++ b/build-aar.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright 2021-2022, Collabora, Ltd.
+#
+# SPDX-License-Identifier: BSL-1.0
+
+set -e
+
+# shellcheck disable=SC2086
+ROOT=$(cd "$(dirname $0)" && pwd)
+PROJECT=percetto
+DEFAULT_NDK_VERSION=21.4.7075529
+
+ANDROID_NDK_HOME=${ANDROID_NDK_HOME:-${HOME}/Android/Sdk/ndk/${DEFAULT_NDK_VERSION}}
+
+if [ ! -f "${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" ]; then
+    echo "Please set ANDROID_NDK_HOME to a valid, installed NDK!"
+    exit 1
+fi
+
+export ANDROID_NDK_HOME
+
+BUILD_DIR=${BUILD_DIR:-${ROOT}/build}
+INSTALL_DIR=${INSTALL_DIR:-${ROOT}/install}
+GENERATION_DIR="${BUILD_DIR}/Android_x86_aar/src"
+
+rm -f "${GENERATION_DIR}/*.pom" || true
+
+rm -rf "${INSTALL_DIR}"
+for arch in x86 x86_64 armeabi-v7a arm64-v8a; do
+    cmake --preset Android_${arch}_aar
+    cmake --build --preset Android_${arch}_aar
+done
+# find latest pom
+DECORATED=$(cd "${GENERATION_DIR}" && find . -maxdepth 1 -name "${PROJECT}*.pom" | sort | tail -n 1)
+# strip leading ./
+DECORATED=${DECORATED#./}
+echo "DECORATED ${DECORATED}"
+DECORATED_STEM=${DECORATED%.pom}
+echo "DECORATED_STEM ${DECORATED_STEM}"
+VERSION=${DECORATED_STEM#${PROJECT}-}
+echo "VERSION ${VERSION}"
+DIR=$(pwd)/maven_repo/io/github/olvaffe/deps/${PROJECT}/${VERSION}
+
+mkdir -p "${DIR}"
+cp "${GENERATION_DIR}/${DECORATED}" "${ROOT}"
+cp "${GENERATION_DIR}/${DECORATED}" "${DIR}"
+
+(
+    cd "$INSTALL_DIR/${PROJECT}"
+    7za a -r ../${PROJECT}.zip ./*
+    mv ../${PROJECT}.zip "$ROOT/${DECORATED_STEM}.aar"
+    cp "$ROOT/${DECORATED_STEM}.aar" "$DIR/${DECORATED_STEM}.aar"
+)

--- a/cmake/PrefabHelper.cmake
+++ b/cmake/PrefabHelper.cmake
@@ -1,0 +1,60 @@
+# Copyright 2020-2021, Collabora, Ltd.
+#
+# SPDX-License-Identifier: BSL-1.0
+#
+# Helpers for creating an android "prefab" archive
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_prefab_mod_dir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+macro(setup_prefab)
+    set(PREFAB_INSTALL_DIR prefab)
+    unset(NDK_MAJOR_VERSION)
+    if(CMAKE_ANDROID_NDK)
+        file(STRINGS "${CMAKE_ANDROID_NDK}/source.properties" NDK_PROPERTIES)
+        foreach(_line ${NDK_PROPERTIES})
+            if("${_line}" MATCHES
+               "Pkg.Revision = ([0-9]+)[.]([0-9]+)[.]([0-9]+)")
+                set(NDK_MAJOR_VERSION ${CMAKE_MATCH_1})
+            endif()
+        endforeach()
+    else()
+        message(FATAL_ERROR "Please set CMAKE_ANDROID_NDK to your NDK root!")
+    endif()
+    if(NDK_MAJOR_VERSION)
+        message(STATUS "Building using NDK major version ${NDK_MAJOR_VERSION}")
+    else()
+        message(
+            FATAL_ERROR
+                "Could not parse the major version from ${CMAKE_ANDROID_NDK}/source.properties"
+        )
+    endif()
+
+    configure_file(${_prefab_mod_dir}/prefab.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/prefab.json @ONLY)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/prefab.json
+        DESTINATION ${PREFAB_INSTALL_DIR}
+        COMPONENT Prefab)
+endmacro()
+
+macro(setup_prefab_module MODULE_NAME)
+    set(PREFAB_MODULE_INSTALL_DIR ${PREFAB_INSTALL_DIR}/modules/${MODULE_NAME})
+    set(CMAKE_INSTALL_LIBDIR
+        ${PREFAB_MODULE_INSTALL_DIR}/libs/android.${ANDROID_ABI})
+    set(CMAKE_INSTALL_BINDIR ${CMAKE_INSTALL_LIBDIR})
+    set(CMAKE_INSTALL_INCLUDEDIR ${PREFAB_MODULE_INSTALL_DIR}/${CMAKE_INSTALL_INCLUDEDIR})
+
+    configure_file(${_prefab_mod_dir}/abi.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/abi.json @ONLY)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/abi.json
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT Prefab)
+
+    install(
+        FILES ${_prefab_mod_dir}/module.json
+        DESTINATION ${PREFAB_MODULE_INSTALL_DIR}
+        COMPONENT Prefab)
+endmacro()

--- a/cmake/abi.json
+++ b/cmake/abi.json
@@ -1,0 +1,6 @@
+{
+    "abi": "@ANDROID_ABI@",
+    "api": @CMAKE_SYSTEM_VERSION@,
+    "ndk": @NDK_MAJOR_VERSION@,
+    "stl": "@ANDROID_STL@"
+}

--- a/cmake/abi.json.license
+++ b/cmake/abi.json.license
@@ -1,0 +1,3 @@
+Copyright 2020-2021, Collabora, Ltd.
+
+SPDX-License-Identifier: BSL-1.0

--- a/cmake/module.json
+++ b/cmake/module.json
@@ -1,0 +1,7 @@
+{
+    "export_libraries": [],
+    "android": {
+        "export_libraries": null,
+        "library_name": null
+    }
+}

--- a/cmake/module.json.license
+++ b/cmake/module.json.license
@@ -1,0 +1,3 @@
+Copyright 2020-2021, Collabora, Ltd.
+
+SPDX-License-Identifier: BSL-1.0

--- a/cmake/percettoConfig.cmake
+++ b/cmake/percettoConfig.cmake
@@ -1,0 +1,10 @@
+# Copyright 2022, Collabora, Ltd.
+#
+# SPDX-License-Identifier: BSL-1.0
+
+include(FeatureSummary)
+set_package_properties(
+    Percetto PROPERTIES
+    URL "https://github.com/olvaffe/percetto/"
+    DESCRIPTION "A C wrapper around the C++ Perfetto tracing SDK.")
+include("${CMAKE_CURRENT_LIST_DIR}/percettoTargets.cmake")

--- a/cmake/prefab.json
+++ b/cmake/prefab.json
@@ -1,0 +1,6 @@
+{
+    "schema_version": 1,
+    "name": "@PROJECT_NAME@",
+    "version": "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.@PROJECT_VERSION_TWEAK@",
+    "dependencies": []
+}

--- a/cmake/prefab.json.license
+++ b/cmake/prefab.json.license
@@ -1,0 +1,3 @@
+Copyright 2020-2021, Collabora, Ltd.
+
+SPDX-License-Identifier: BSL-1.0

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2021-2022, Collabora, Ltd.
+#
+# SPDX-License-Identifier: BSL-1.0
+
+add_executable(multi-category multi-category.c)
+target_link_libraries(multi-category PRIVATE percetto::percetto)
+
+add_executable(timestamps timestamps.c)
+target_link_libraries(timestamps PRIVATE percetto::percetto)
+
+add_executable(threads threads.cc)
+target_link_libraries(threads PRIVATE percetto::percetto)
+
+add_executable(perf-test perf-test.cc)
+target_link_libraries(perf-test PRIVATE percetto::percetto)
+
+add_library(multi-perfetto-shlib SHARED multi-perfetto-shlib.c)
+target_link_libraries(multi-perfetto-shlib PUBLIC percetto::percetto)
+
+add_executable(multi-perfetto-instance multi-perfetto-instance.c)
+target_link_libraries(multi-perfetto-instance PRIVATE multi-perfetto-shlib)
+
+if(ANDROID)
+    add_executable(atrace atrace.cc atrace2.c)
+    target_link_libraries(atrace PRIVATE percetto::atrace-percetto)
+endif()

--- a/src/AndroidManifest.xml
+++ b/src/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="io.github.olvaffe.percetto">
+  <!--
+      Copyright 2022, Collabora, Ltd.
+      SPDX-License-Identifier: BSL-1.0
+  -->
+</manifest>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,7 @@ install(
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(ANDROID)
-    target_link_libraries(percetto PRIVATE ${ANDROID_LOG})
+    target_link_libraries(percetto PUBLIC ${ANDROID_LOG})
 endif()
 
 # Provide alias so that examples can work the same as out-of-project usage.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,69 @@
+# Copyright 2021-2022, Collabora, Ltd.
+#
+# SPDX-License-Identifier: BSL-1.0
+
+# PerCetto
+add_library(percetto SHARED percetto.cc perfetto-port.cc $<TARGET_OBJECTS:perfetto>)
+target_compile_options(percetto PRIVATE -ffunction-sections -fdata-sections)
+target_link_libraries(percetto PUBLIC Threads::Threads)
+target_link_options(percetto PRIVATE -Wl,--gc-sections -Wl,--exclude-libs,ALL)
+set_target_properties(
+    percetto
+    PROPERTIES
+        CXX_VISIBILITY_PRESET hidden
+        C_VISIBILITY_PRESET hidden
+        SOVERSION ${PERCETTO_SONAME_VERSION}
+        VERSION ${PERCETTO_SONAME_VERSION})
+target_include_directories(percetto PUBLIC $<BUILD_INTERFACE:${PERFETTO_SDK_PATH}>)
+target_include_directories(percetto PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+install(FILES percetto.h perfetto-port.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(
+    TARGETS percetto
+    EXPORT percetto
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+if(ANDROID)
+    target_link_libraries(percetto PRIVATE ${ANDROID_LOG})
+endif()
+
+# Provide alias so that examples can work the same as out-of-project usage.
+add_library(percetto::percetto ALIAS percetto)
+
+if(ANDROID)
+    # Percetto ATRACE wrapper
+
+    # Warning: PrefabPackageTask.findLibraryForAbi only looks if a file "starts with"
+    # a given name, so libraries must not be prefixes of each other.
+    # That is why this is called atrace-percetto and not percetto-atrace.
+    # The error is very cryptic, mentioning more than one item in a container.
+    # see https://android.googlesource.com/platform/tools/base/+/d6150e09027e8248d2a1c801b609f0a1db9a297e/build-system/gradle-core/main/java/com/android/build/gradle/internal/tasks/PrefabPublishing.kt#246
+    add_library(atrace-percetto SHARED percetto-atrace.c)
+    target_link_libraries(atrace-percetto PUBLIC percetto Threads::Threads)
+    set_target_properties(atrace-percetto PROPERTIES CXX_VISIBILITY_PRESET hidden
+                                                     C_VISIBILITY_PRESET hidden)
+    target_link_options(atrace-percetto PRIVATE -Wl,--gc-sections -Wl,--exclude-libs,ALL)
+
+    # Provide alias so that examples can work the same as out-of-project usage.
+    add_library(percetto::atrace-percetto ALIAS atrace-percetto)
+
+    # Installing
+    install(FILES percetto-atrace.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(
+        TARGETS atrace-percetto
+        EXPORT percetto
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+    if(INSTALL_FOR_PREFAB)
+        install(FILES AndroidManifest.xml DESTINATION .)
+        # This gets used directly by build-aar.sh
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pom
+                       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-${PROJECT_VERSION}.pom)
+    endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,18 @@ set_target_properties(
 target_include_directories(percetto PUBLIC $<BUILD_INTERFACE:${PERFETTO_SDK_PATH}>)
 target_include_directories(percetto PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    # Limit what symbols are exported
+    set_property(
+        TARGET percetto
+        APPEND_STRING
+        PROPERTY LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/percetto.exports")
+    # Re-link if the version script changes.
+    set_property(
+        TARGET percetto
+        APPEND
+        PROPERTY LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/percetto.exports")
+endif()
 install(FILES percetto.h perfetto-port.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(
     TARGETS percetto

--- a/src/percetto.exports
+++ b/src/percetto.exports
@@ -1,0 +1,14 @@
+{
+  global:
+    percetto_register_group_category;
+    percetto_register_track;
+    percetto_event_begin;
+    percetto_event_end;
+    percetto_event;
+    percetto_event_extended;
+    percetto_init_with_args;
+    percetto_init;
+
+  local:
+    *;
+};

--- a/src/percetto.pom
+++ b/src/percetto.pom
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <!--
+    Copyright 2021-2022, Collabora, Ltd.
+
+    SPDX-License-Identifier: BSL-1.0
+    -->
+    <groupId>io.github.olvaffe</groupId>
+    <artifactId>@PROJECT_NAME@</artifactId>
+    <version>@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.@PROJECT_VERSION_TWEAK@</version>
+    <packaging>aar</packaging>
+    <name>PerCetto</name>
+    <description>@PROJECT_DESCRIPTION@</description>
+    <url>https://github.com/olvaffe/percetto</url>
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+</project>


### PR DESCRIPTION
For ease of integration with Gradle, etc. I had put together this CMake-based build. This builds on #17 (which turned out to still be necessary - it looks like it varies by platform for ndk builds). Thanks to @utzcoz I was able to drop the other patches from this PR.

This also gives you the ability to build AAR files with "prefab" metadata so they can be consumed by Gradle-based Android projects, with just `./build-aar.sh` .